### PR TITLE
Update locale.cfg

### DIFF
--- a/locale/pt-BR/locale.cfg
+++ b/locale/pt-BR/locale.cfg
@@ -3,7 +3,7 @@ warehouse-basic = Armazém
 warehouse-passive-provider = Armazém Provedor
 warehouse-storage = Armazém de Armazenagem
 warehouse-active-provider = Armazém Provedor Ativo
-warehouse-requester = Armazém Requisitor
+warehouse-requester = Armazém Solicitador
 warehouse-smart = Armazém Inteligente
 
 storehouse-basic = Depósito
@@ -17,8 +17,8 @@ storehouse-smart = Depósito Inteligente
 warehouse-basic = Armazém
 warehouse-passive-provider = Armazém Provedor
 warehouse-storage = Armazém de Armazenagem
-warehouse-active-provider = Active Provider Armazém
-warehouse-requester =  Armazém Requisitor
+warehouse-active-provider = Armazém Provedor Ativo
+warehouse-requester =  Armazém Solicitador
 warehouse-smart = Armazém Inteligente
 
 storehouse-basic = Depósito
@@ -30,18 +30,18 @@ storehouse-smart = Depósito Inteligente
 
 [item-description]
 warehouse-basic = Armazena diversos ítens
-warehouse-passive-provider = Armazena diversos item alem de prover ao sistema logistico
+warehouse-passive-provider = Armazena diversos itens alem de fornecer ao sistema logistico
 warehouse-storage = Armazena diversos itens inclusive armazenagems do sistema logístico
-warehouse-active-provider = Armazena diversos item provendo de forma ativa ao sistema logistico
+warehouse-active-provider = Armazena diversos itens provendo de forma ativa ao sistema logistico
 warehouse-requester = Armazena diversos itens podendo solicitar itens ao sistema logistico
-warehouse-smart = Armazena diversos itens podendo utilizar a rede logica para controle inteligente
+warehouse-smart = Armazena diversos itens podendo utilizar a rede logística para controle inteligente
 
 storehouse-basic = Armazena diversos ítens
-storehouse-passive-provider = Armazena diversos item alem de prover ao sistema logistico
+storehouse-passive-provider = Armazena diversos itens alem de fornecer ao sistema logistico
 storehouse-storage = Armazena diversos itens inclusive armazenagems do sistema logístico
-storehouse-active-provider = Armazena diversos item provendo de forma ativa ao sistema logistico
+storehouse-active-provider = Armazena diversos itens provendo de forma ativa ao sistema logistico
 storehouse-requester = Armazena diversos itens podendo solicitar itens ao sistema logistico
-storehouse-smart = Armazena diversos itens podendo utilizar a rede logica para controle inteligente
+storehouse-smart = Armazena diversos itens podendo utilizar a rede logística para controle inteligente
 
 [technology-name]
 warehouse-research = Armazéns


### PR DESCRIPTION
- Requesters are translated in 2 different ways ("requisidor" and "solicitador"). Changed to keep consistency with current vanilla translation ("solicitador")

- changed "logistic network" translation to match vanilla ("rede logística)

- fixed typos