### PR TITLE
Trivial rebalancing of research requirements

### DIFF
--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -24,8 +24,12 @@ data:extend(
 		prerequisites = {"steel-processing"},
 		unit =
 		{
-			count = 40,
-			ingredients = {{ "science-pack-1", 1}},
+			count = 50,
+			ingredients =
+			{
+				{ "science-pack-1", 1},
+				{ "science-pack-2", 1},
+			},
 			time = 20
 		},
 		order = "c-a"
@@ -73,12 +77,13 @@ data:extend(
 		prerequisites = { "warehouse-research", "logistic-system" },
 		unit =
 		{
-			count = 25,
+			count = 100,
 			ingredients = {
-				{ "science-pack-1", 2},
-				{ "science-pack-2", 2},
+				{ "science-pack-1", 1},
+				{ "science-pack-2", 1},
 				{ "science-pack-3", 1},
 				{ "production-science-pack", 1},
+				{ "high-tech-science-pack", 1},
 			},
 			time = 30
 		},


### PR DESCRIPTION
Round count for basic warehouse tech from 40 to 50, add science-pack-2

Raise count for logistic warehousing closer to base game logistics tech, consume all packs equally, add high-tech packs to match base tech.

Fixes #20. Ref: #19.