### PR TITLE
Base logistics warehousing research cost on Logistic System cost

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,9 @@ Go grab it now, or get it in game by searching for Warehousing.
 
 ### Latest
 
-Now compatible with Factorio 0.15! Research requirements have changed, so be warned for new games.
+Now compatible with Factorio 0.16! Research requirements have changed (again), so be warned for new games.
+
+Logistic warehouse research cost is now based on the cost of "Logistic System", for balance when using mods that alter that research. Some mods may alter it too late for Warehousing to use the new values; report these incompatible mods in [the forum thread](https://forums.factorio.com/viewtopic.php?f=93&t=17295) or [GitHub issue tracker](https://github.com/Anoyomouse/Warehousing/issues) and they should be fixable.
 
 ### Previously
 

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,0 +1,9 @@
+require("util")
+
+-- We have a default research cost defined in technology.lua,
+-- but copying the game's dynamically was a requested feature.
+--
+-- Done in data-final-fixes because other mods that override the
+-- cost of logistics research use both earlier steps.
+data.raw["technology"]["warehouse-logistics-research"].unit =
+	table.deepcopy(data.raw["technology"]["logistic-system"].unit)


### PR DESCRIPTION
Players who use mods to reduce the cost of Logistic System will appreciate this.

Used `data-final-fixes.lua` to copy the tech cost as late as possible, but it's possible that some mod which alters the cost of Logistic System in the base game will also use the same load step. They can be made to load first by adding them as optional dependencies of this mod.

Ref: #19