### PR TITLE
Add safety check when copying logistic-system cost

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -5,5 +5,8 @@ require("util")
 --
 -- Done in data-final-fixes because other mods that override the
 -- cost of logistics research use both earlier steps.
-data.raw["technology"]["warehouse-logistics-research"].unit =
-	table.deepcopy(data.raw["technology"]["logistic-system"].unit)
+if data.raw["technology"]["logistic-system"] ~= nil
+	and data.raw["technology"]["logistic-system"].unit ~= nil then
+		data.raw["technology"]["warehouse-logistics-research"].unit =
+			table.deepcopy(data.raw["technology"]["logistic-system"].unit)
+end


### PR DESCRIPTION
It's highly unlikely that the Logistic System tech will ever be missing, but just in case someone is using a mod that disables it, Warehousing should see if the tech exists first before trying to copy its research cost data.